### PR TITLE
Added Timer, Deathcount and analytics for both

### DIFF
--- a/By a Thread/Assets/Scenes/SampleScene.unity
+++ b/By a Thread/Assets/Scenes/SampleScene.unity
@@ -3395,6 +3395,7 @@ GameObject:
   - component: {fileID: 1754240609}
   - component: {fileID: 1754240610}
   - component: {fileID: 1754240611}
+  - component: {fileID: 1754240612}
   m_Layer: 0
   m_Name: GameController
   m_TagString: Untagged
@@ -3418,6 +3419,8 @@ MonoBehaviour:
     virtualCamera: {fileID: 1946717924}
     player: {fileID: 838423048}
     player2: {fileID: 999188169}
+    level: 1
+    DeathCount: 0
     spawnPoint: {fileID: 421228357}
     jumpModifier: 0.9
     jumpDeceleration: 0
@@ -3560,6 +3563,20 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!114 &1754240612
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1754240606}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57913f53f4d744069b6e14e945bd2ca6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timeStart: 0
+  timerActive: 1
 --- !u!1 &1946717923
 GameObject:
   m_ObjectHideFlags: 0

--- a/By a Thread/Assets/Scenes/SampleScene.unity
+++ b/By a Thread/Assets/Scenes/SampleScene.unity
@@ -3421,6 +3421,7 @@ MonoBehaviour:
     player2: {fileID: 999188169}
     level: 1
     DeathCount: 0
+    T: {fileID: 1754240612}
     spawnPoint: {fileID: 421228357}
     jumpModifier: 0.9
     jumpDeceleration: 0

--- a/By a Thread/Assets/Scripts/Core/MoveScene.cs
+++ b/By a Thread/Assets/Scripts/Core/MoveScene.cs
@@ -37,7 +37,7 @@ public class MoveScene : MonoBehaviour
         {
           { "Level", model.level.ToString()},
           { "Attempts", model.DeathCount},
-          {"TimeToComplete", model.T.timeStart}
+          {"Time", model.T.timeStart}
         };
         
         Events.CustomData("LevelComplete", parameters);

--- a/By a Thread/Assets/Scripts/Core/MoveScene.cs
+++ b/By a Thread/Assets/Scripts/Core/MoveScene.cs
@@ -36,7 +36,7 @@ public class MoveScene : MonoBehaviour
         Dictionary<string, object> parameters = new Dictionary<string, object>()
         {
           { "Level", model.level.ToString()},
-          { "DeathCount", model.DeathCount},
+          { "Attempts", model.DeathCount},
           {"TimeToComplete", model.T.timeStart}
         };
         

--- a/By a Thread/Assets/Scripts/Core/MoveScene.cs
+++ b/By a Thread/Assets/Scripts/Core/MoveScene.cs
@@ -31,10 +31,13 @@ public class MoveScene : MonoBehaviour
       if(other.CompareTag("Player")) {
         
         PlatformerModel model = Simulation.GetModel<PlatformerModel>();
+        model.T.timerActive = false;
         
         Dictionary<string, object> parameters = new Dictionary<string, object>()
         {
-          { "Level", model.level}
+          { "Level", model.level.ToString()},
+          { "DeathCount", model.DeathCount.ToString()},
+          {"TimeToComplete", model.T.timeStart.ToString()}
         };
         
         Events.CustomData("LevelComplete", parameters);

--- a/By a Thread/Assets/Scripts/Core/MoveScene.cs
+++ b/By a Thread/Assets/Scripts/Core/MoveScene.cs
@@ -36,8 +36,8 @@ public class MoveScene : MonoBehaviour
         Dictionary<string, object> parameters = new Dictionary<string, object>()
         {
           { "Level", model.level.ToString()},
-          { "DeathCount", model.DeathCount.ToString()},
-          {"TimeToComplete", model.T.timeStart.ToString()}
+          { "DeathCount", model.DeathCount},
+          {"TimeToComplete", model.T.timeStart}
         };
         
         Events.CustomData("LevelComplete", parameters);

--- a/By a Thread/Assets/Scripts/Core/Timer.cs
+++ b/By a Thread/Assets/Scripts/Core/Timer.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class Timer : MonoBehaviour {
+    public float timeStart = 0.0f;
+    public bool timerActive = true;
+
+    // Use this for initialization
+    void Start () {
+
+    }
+	
+    // Update is called once per frame
+    void Update () {
+        if(timerActive){
+            timeStart += Time.deltaTime;
+        }
+    }
+}

--- a/By a Thread/Assets/Scripts/Core/Timer.cs.meta
+++ b/By a Thread/Assets/Scripts/Core/Timer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 57913f53f4d744069b6e14e945bd2ca6
+timeCreated: 1646026960

--- a/By a Thread/Assets/Scripts/Gameplay/PlayerDeath.cs
+++ b/By a Thread/Assets/Scripts/Gameplay/PlayerDeath.cs
@@ -20,10 +20,14 @@ namespace Platformer.Gameplay
         {
             KillPlayer(model.player2);
             KillPlayer(model.player);
+            
         }
 
         public void KillPlayer(PlayerController player)
         {
+
+
+            
             if (player.health.IsAlive)
             {
                 player.health.Die();

--- a/By a Thread/Assets/Scripts/Gameplay/PlayerSpawnNew.cs
+++ b/By a Thread/Assets/Scripts/Gameplay/PlayerSpawnNew.cs
@@ -16,6 +16,13 @@ namespace Platformer.Gameplay
 
         public override void Execute()
         {
+            
+            // idk why but having this code in playerDeath gives incorrect values
+            if (player == model.player) 
+            {
+                model.DeathCount += 1;
+            }
+            
             player.spriteRenderer.enabled = true;
             player.collider2d.enabled = true;
             player.controlEnabled = false;

--- a/By a Thread/Assets/Scripts/Gameplay/Spikes.cs
+++ b/By a Thread/Assets/Scripts/Gameplay/Spikes.cs
@@ -34,7 +34,7 @@ public class Spikes : MonoBehaviour
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>()
             {
-                { "Level", model.level},
+                { "Level", model.level.ToString()},
                 { "Zone", this.name }
             };
             

--- a/By a Thread/Assets/Scripts/Mechanics/DeathZone.cs
+++ b/By a Thread/Assets/Scripts/Mechanics/DeathZone.cs
@@ -38,7 +38,7 @@ namespace Platformer.Mechanics
             {
                 Dictionary<string, object> parameters = new Dictionary<string, object>()
                 {
-                    { "Level", model.level},
+                    { "Level", model.level.ToString()},
                     { "Zone", this.name }
                 };
                 

--- a/By a Thread/Assets/Scripts/Model/PlatformerModel.cs
+++ b/By a Thread/Assets/Scripts/Model/PlatformerModel.cs
@@ -22,7 +22,9 @@ namespace Platformer.Model
         /// </summary>
         public PlayerController player;
         public PlayerController player2;
-        public string level= "1";
+        public int level= 1;
+        public int DeathCount = 0;
+        public Timer T;
 
         /// <summary>
         /// The spawn point in the scene.


### PR DESCRIPTION
Added the following analytics and changes:

Level Timer 
DeathCounter

Both are hidden atm - but very easy change if we want to make them visible

Avg Session time: Unity tracks this. It can be accessed in the unity analytics dashboard thru Daily Playtime per daily active user or by taking the avg of session length.